### PR TITLE
feature/recipe-backend-favorites

### DIFF
--- a/backend/src/main/java/com/ecosystem/backend/controller/FavoritesController.java
+++ b/backend/src/main/java/com/ecosystem/backend/controller/FavoritesController.java
@@ -1,0 +1,31 @@
+package com.ecosystem.backend.controller;
+
+import com.ecosystem.backend.models.Recipe;
+import com.ecosystem.backend.repository.RecipeRepository;
+import com.ecosystem.backend.services.FavoritesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/favorites")
+@RequiredArgsConstructor
+public class FavoritesController {
+
+    private final FavoritesService favoritesService;
+    private final RecipeRepository recipeRepository;
+
+    @GetMapping("/recipes")
+    public List<Recipe> getFavoriteRecipes(@AuthenticationPrincipal OAuth2User user) {
+        List<String> ids = favoritesService.getFavoriteIds(user.getName());
+        return recipeRepository.findAllById(ids);
+    }
+
+    @PostMapping("/{recipeId}/toggle")
+    public void toggleFavorite(@PathVariable String recipeId, @AuthenticationPrincipal OAuth2User user) {
+        favoritesService.toggleFavorite(user.getName(), recipeId);
+    }
+}

--- a/backend/src/main/java/com/ecosystem/backend/models/Favorites.java
+++ b/backend/src/main/java/com/ecosystem/backend/models/Favorites.java
@@ -1,0 +1,18 @@
+package com.ecosystem.backend.models;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "favorites")
+public record Favorites(@Id String id, @Indexed(unique = true) String userId, List<String> recipeIds) {
+
+    public Favorites {
+        if (recipeIds == null) {
+            recipeIds = new ArrayList<>();
+        }
+    }
+}

--- a/backend/src/main/java/com/ecosystem/backend/repository/FavoritesRepository.java
+++ b/backend/src/main/java/com/ecosystem/backend/repository/FavoritesRepository.java
@@ -1,0 +1,10 @@
+package com.ecosystem.backend.repository;
+
+import com.ecosystem.backend.models.Favorites;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface FavoritesRepository extends MongoRepository<Favorites, String> {
+    Optional<Favorites> findByUserId(String userId);
+}

--- a/backend/src/main/java/com/ecosystem/backend/services/FavoritesService.java
+++ b/backend/src/main/java/com/ecosystem/backend/services/FavoritesService.java
@@ -1,0 +1,36 @@
+package com.ecosystem.backend.services;
+
+import com.ecosystem.backend.models.Favorites;
+import com.ecosystem.backend.repository.FavoritesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FavoritesService {
+
+    private final FavoritesRepository favoritesRepository;
+
+    private Favorites getOrCreate(String userId) {
+        return favoritesRepository.findByUserId(userId)
+                .orElseGet(() -> favoritesRepository.save(new Favorites(null, userId, new ArrayList<>())));
+    }
+
+    public List<String> getFavoriteIds(String userId) {
+        return new ArrayList<>(getOrCreate(userId).recipeIds());
+    }
+
+    public void toggleFavorite(String userId, String recipeId) {
+        Favorites favorites = getOrCreate(userId);
+        List<String> ids = new ArrayList<>(favorites.recipeIds());
+        if (ids.contains(recipeId)) {
+            ids.remove(recipeId);
+        } else {
+            ids.add(recipeId);
+        }
+        favoritesRepository.save(new Favorites(favorites.id(), favorites.userId(), ids));
+    }
+}

--- a/backend/src/test/java/com/ecosystem/backend/controller/FavoritesControllerTest.java
+++ b/backend/src/test/java/com/ecosystem/backend/controller/FavoritesControllerTest.java
@@ -1,0 +1,87 @@
+package com.ecosystem.backend.controller;
+
+import com.ecosystem.backend.models.Favorites;
+import com.ecosystem.backend.models.Recipe;
+import com.ecosystem.backend.repository.FavoritesRepository;
+import com.ecosystem.backend.repository.RecipeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FavoritesControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    FavoritesRepository favoritesRepo;
+
+    @Autowired
+    RecipeRepository recipeRepo;
+
+    private static final String USER_ID = "user123";
+    private static final String R1 = "spaghetti";
+    private static final String R2 = "tortellini";
+
+    @BeforeEach
+    void clearDb() {
+        favoritesRepo.deleteAll();
+        recipeRepo.deleteAll();
+    }
+
+    @Test
+    void shouldAddRecipeOnToggle() throws Exception {
+
+        // GIVEN
+        favoritesRepo.save(new Favorites(null, USER_ID, List.of()));
+
+        // WHEN+THEN
+        mockMvc.perform(post("/api/favorites/" + R1 + "/toggle")
+                        .with(oidcLogin().idToken(t -> t.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldRemoveRecipeOnToggle() throws Exception {
+
+        // GIVEN
+        favoritesRepo.save(new Favorites(null, USER_ID, List.of(R1, R2)));
+
+        // WHEN+THEN
+        mockMvc.perform(post("/api/favorites/" + R1 + "/toggle")
+                        .with(oidcLogin().idToken(t -> t.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldFetchFavoriteRecipes() throws Exception {
+
+        // GIVEN
+        Recipe rec = new Recipe(R1, "Pizza", 3.0, List.of(), "mit Salami");
+        recipeRepo.save(rec);
+        favoritesRepo.save(new Favorites(null, USER_ID, List.of(R1)));
+
+        // WHEN+THEN
+        mockMvc.perform(get("/api/favorites/recipes")
+                        .with(oidcLogin().idToken(t -> t.subject(USER_ID)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(R1))
+                .andExpect(jsonPath("$[0].name").value("Pizza"));
+    }
+}

--- a/backend/src/test/java/com/ecosystem/backend/services/FavoritesServiceTest.java
+++ b/backend/src/test/java/com/ecosystem/backend/services/FavoritesServiceTest.java
@@ -1,0 +1,86 @@
+package com.ecosystem.backend.services;
+
+import com.ecosystem.backend.models.Favorites;
+import com.ecosystem.backend.repository.FavoritesRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FavoritesServiceTest {
+
+    FavoritesRepository repository = Mockito.mock(FavoritesRepository.class);
+    FavoritesService service = new FavoritesService(repository);
+
+    private static final String USER_ID = "user123";
+    private static final String R1 = "spaghetti";
+    private static final String R2 = "pizza";
+
+    @Test
+    void shouldReturnEmptyListForNewUser() {
+
+        // GIVEN
+        when(repository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+        when(repository.save(any(Favorites.class)))
+                .thenAnswer(inv -> new Favorites("fav1", USER_ID, new ArrayList<>()));
+
+        // WHEN
+        List<String> ids = service.getFavoriteIds(USER_ID);
+
+        // THEN
+        assertTrue(ids.isEmpty());
+        verify(repository).findByUserId(USER_ID);
+        verify(repository).save(any(Favorites.class));
+    }
+
+    @Test
+    void shouldReturnExistingIds() {
+
+        // GIVEN
+        when(repository.findByUserId(USER_ID))
+                .thenReturn(Optional.of(new Favorites("fav1", USER_ID, List.of(R1, R2))));
+
+        // WHEN
+        List<String> ids = service.getFavoriteIds(USER_ID);
+
+        // THEN
+        assertEquals(List.of(R1, R2), ids);
+    }
+
+    @Test
+    void shouldAddIdOnToggle() {
+
+        // GIVEN
+        when(repository.findByUserId(USER_ID))
+                .thenReturn(Optional.of(new Favorites("fav1", USER_ID, new ArrayList<>())));
+        when(repository.save(any(Favorites.class)))
+                .thenReturn(new Favorites("fav1", USER_ID, List.of(R1)));
+
+        // WHEN
+        service.toggleFavorite(USER_ID, R1);
+
+        // THEN
+        verify(repository).save(new Favorites("fav1", USER_ID, List.of(R1)));
+    }
+
+    @Test
+    void shouldRemoveIdOnToggle() {
+
+        // GIVEN
+        when(repository.findByUserId(USER_ID))
+                .thenReturn(Optional.of(new Favorites("fav1", USER_ID, List.of(R1, R2))));
+        when(repository.save(any(Favorites.class)))
+                .thenReturn(new Favorites("fav1", USER_ID, List.of(R2)));
+
+        // WHEN
+        service.toggleFavorite(USER_ID, R1);
+
+        // THEN
+        verify(repository).save(new Favorites("fav1", USER_ID, List.of(R2)));
+    }
+}


### PR DESCRIPTION

1. Controller:

- Implemented FavoritesController with API.
- Added GET /api/favorites/recipes to fetch favorite recipes of the logged-in user.
- Added POST /api/favorites/{id}/toggle to add or remove a recipe as favorite.

2. Models:

- Added Favorites document model for MongoDB.
- Fields: id, userId (unique, indexed), recipeIds (never null).

3. Repository:

- Added FavoritesRepository interface.
- Extended MongoRepository<Favorites, String>.
- Custom query method: findByUserId(String userId).

4. Service:

- Implemented FavoritesService.
- getFavoriteIds(userId) → returns list of favorite IDs.
- toggleFavorite(userId, recipeId), adds or removes a recipe from favorites.
- Internal method getOrCreate(userId) ensures that a document always exists. 
- Added Unique User ID in MongoDB.

5. Controller Tests:

- Added FavoritesControllerTest with MockMvc integration tests.
- Add recipe as favorite (toggle).
- Remove recipe from favorites (toggle).
- Fetch favorite recipes.

6. Service Tests:

- Added FavoritesServiceTest with Mockito unit tests.
- New user starts with empty favorites.
- Existing favorites are returned correctly.
- Toggle adds a recipe.
- Toggle removes a recipe.